### PR TITLE
Upstream: Add explicit "--build" to our "./configure" invocations

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -26,6 +26,8 @@ RUN set -ex \
         && rm python.tar.xz \
         \
         && apk add --no-cache --virtual .build-deps  \
+            coreutils \
+            dpkg-dev dpkg \
             tcl-dev \
             tk \
             tk-dev \
@@ -33,10 +35,12 @@ RUN set -ex \
         && apk del .fetch-deps \
         \
         && cd /usr/src/python \
+        && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
         && ./configure \
+            --build="$gnuArch" \
             --enable-shared \
             --enable-unicode=ucs4 \
-        && make -j$(getconf _NPROCESSORS_ONLN) \
+        && make -j$(nproc) \
         && make install \
         \
         && runDeps="$( \

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -26,6 +26,8 @@ RUN set -ex \
         && rm python.tar.xz \
         \
         && apk add --no-cache --virtual .build-deps  \
+            coreutils \
+            dpkg-dev dpkg \
             tcl-dev \
             tk \
             tk-dev \
@@ -33,11 +35,13 @@ RUN set -ex \
         && apk del .fetch-deps \
         \
         && cd /usr/src/python \
+        && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
         && ./configure \
+            --build="$gnuArch" \
             --enable-loadable-sqlite-extensions \
             --enable-shared \
             --without-ensurepip \
-        && make -j$(getconf _NPROCESSORS_ONLN) \
+        && make -j$(nproc) \
         && make install \
         \
         && runDeps="$( \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -26,6 +26,8 @@ RUN set -ex \
         && rm python.tar.xz \
         \
         && apk add --no-cache --virtual .build-deps  \
+            coreutils \
+            dpkg-dev dpkg \
             tcl-dev \
             tk \
             tk-dev \
@@ -33,11 +35,13 @@ RUN set -ex \
         && apk del .fetch-deps \
         \
         && cd /usr/src/python \
+        && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
         && ./configure \
+            --build="$gnuArch" \
             --enable-loadable-sqlite-extensions \
             --enable-shared \
             --without-ensurepip \
-        && make -j$(getconf _NPROCESSORS_ONLN) \
+        && make -j$(nproc) \
         && make install \
         \
         && runDeps="$( \


### PR DESCRIPTION
* docker-library/python#198

This won't affect us but keep the code the same as upstream.